### PR TITLE
chore: Migrate GitHub Actions to release-please v5 and update action versions

### DIFF
--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check-out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Define development release info
         if: startsWith(github.ref, 'refs/heads/')
@@ -41,13 +41,13 @@ jobs:
 
       - name: Publish build artifacts
         if: env.DO_BUILD
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build_artifacts
           path: ${{ env.DIST_DIR }}
 
       - name: Update development release tag
-        uses: fortify/3rdparty-actions/actions/richardsimko/update-tag/v1@main
+        uses: fortify/.github/.github/actions/update-tag@main
         if: env.DO_RELEASE
         with:
           tag_name: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -18,13 +18,15 @@ jobs:
       issues: write
     steps:
       - name: Check-out source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate and process release PR
         id: release_please
         uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
           release-type: simple
+          skip-github-release: true
+          target-branch: ${{ github.ref_name }}
 
       - name: Define production release info
         if: steps.release_please.outputs.release_created

--- a/.github/workflows/build-prod-release.yml
+++ b/.github/workflows/build-prod-release.yml
@@ -25,7 +25,6 @@ jobs:
         uses: fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main
         with:
           release-type: simple
-          skip-github-release: true
           target-branch: ${{ github.ref_name }}
 
       - name: Define production release info

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,7 @@
+{
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix",  "section": "Bug Fixes", "hidden": false },
+    { "type": "api",  "section": "API changes", "hidden": false }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,0 @@
-{
-  "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "fix",  "section": "Bug Fixes", "hidden": false },
-    { "type": "api",  "section": "API changes", "hidden": false }
-  ]
-}


### PR DESCRIPTION
Migrate from GoogleCloudPlatform/release-please-action@v2 to 
fortify/3rdparty-actions/actions/googleapis/release-please-action/v5@main 
and update GitHub Actions to current versions.

Changes:
- Update actions/checkout@v4 → v6
- Update actions/upload-artifact@v4 → v7
- Update update-tag action to fortify/.github/.github/actions/update-tag@main
- Add skip-github-release and target-branch parameters to release-please
- Add release-please-config.json with changelog sections configuration